### PR TITLE
Integrate PostgreSQL and NiceAdmin template

### DIFF
--- a/AppDiti2025/AppDiti2025.csproj
+++ b/AppDiti2025/AppDiti2025.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.14"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.14"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.3"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14"/>
     </ItemGroup>
 

--- a/AppDiti2025/Controllers/AdminsController.cs
+++ b/AppDiti2025/Controllers/AdminsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AppDiti2025.Data;
+using AppDiti2025.Models;
+
+namespace AppDiti2025.Controllers;
+
+public class AdminsController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public AdminsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // GET: Admins
+    public async Task<IActionResult> Index()
+    {
+        return View(await _context.Admins.ToListAsync());
+    }
+}

--- a/AppDiti2025/Controllers/ClientsController.cs
+++ b/AppDiti2025/Controllers/ClientsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AppDiti2025.Data;
+using AppDiti2025.Models;
+
+namespace AppDiti2025.Controllers;
+
+public class ClientsController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public ClientsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // GET: Clients
+    public async Task<IActionResult> Index()
+    {
+        return View(await _context.Clients.ToListAsync());
+    }
+}

--- a/AppDiti2025/Data/ApplicationDbContext.cs
+++ b/AppDiti2025/Data/ApplicationDbContext.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace AppDiti2025.Data;
+
+using AppDiti2025.Models;
 
 public class ApplicationDbContext : IdentityDbContext
 {
@@ -9,4 +11,7 @@ public class ApplicationDbContext : IdentityDbContext
         : base(options)
     {
     }
+
+    public DbSet<Admin> Admins { get; set; } = default!;
+    public DbSet<Client> Clients { get; set; } = default!;
 }

--- a/AppDiti2025/Models/Admin.cs
+++ b/AppDiti2025/Models/Admin.cs
@@ -1,0 +1,6 @@
+namespace AppDiti2025.Models;
+
+public class Admin : Utilisateur
+{
+    public string? Role { get; set; }
+}

--- a/AppDiti2025/Models/Client.cs
+++ b/AppDiti2025/Models/Client.cs
@@ -1,0 +1,6 @@
+namespace AppDiti2025.Models;
+
+public class Client : Utilisateur
+{
+    public string? Adresse { get; set; }
+}

--- a/AppDiti2025/Models/Personne.cs
+++ b/AppDiti2025/Models/Personne.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AppDiti2025.Models;
+
+public abstract class Personne
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Nom { get; set; } = string.Empty;
+
+    [Required]
+    public string Prenom { get; set; } = string.Empty;
+}

--- a/AppDiti2025/Models/Utilisateur.cs
+++ b/AppDiti2025/Models/Utilisateur.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AppDiti2025.Models;
+
+public abstract class Utilisateur : Personne
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    public string? Telephone { get; set; }
+}

--- a/AppDiti2025/Program.cs
+++ b/AppDiti2025/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ??
                        throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlite(connectionString));
+    options.UseNpgsql(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)

--- a/AppDiti2025/Views/Admins/Index.cshtml
+++ b/AppDiti2025/Views/Admins/Index.cshtml
@@ -1,0 +1,26 @@
+@model IEnumerable<AppDiti2025.Models.Admin>
+@{
+    ViewData["Title"] = "Admins";
+}
+<h1>Admins</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Nom</th>
+            <th>Prenom</th>
+            <th>Email</th>
+            <th>Role</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@item.Nom</td>
+            <td>@item.Prenom</td>
+            <td>@item.Email</td>
+            <td>@item.Role</td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/AppDiti2025/Views/Clients/Index.cshtml
+++ b/AppDiti2025/Views/Clients/Index.cshtml
@@ -1,0 +1,26 @@
+@model IEnumerable<AppDiti2025.Models.Client>
+@{
+    ViewData["Title"] = "Clients";
+}
+<h1>Clients</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Nom</th>
+            <th>Prenom</th>
+            <th>Email</th>
+            <th>Adresse</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@item.Nom</td>
+            <td>@item.Prenom</td>
+            <td>@item.Email</td>
+            <td>@item.Adresse</td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/AppDiti2025/Views/Shared/_Layout.cshtml
+++ b/AppDiti2025/Views/Shared/_Layout.cshtml
@@ -1,50 +1,28 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - AppDiti2025</title>
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css"/>
-    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true"/>
-    <link rel="stylesheet" href="~/AppDiti2025.styles.css" asp-append-version="true"/>
+    <link href="~/niceadmin/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="~/niceadmin/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet" />
+    <link href="~/niceadmin/css/style.css" rel="stylesheet" />
 </head>
 <body>
-<header>
-    <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
-        <div class="container-fluid">
-            <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">AppDiti2025</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                    aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                <ul class="navbar-nav flex-grow-1">
-                    <li class="nav-item">
-                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                    </li>
-                </ul>
-                <partial name="_LoginPartial"/>
-            </div>
+    <header id="header" class="header fixed-top d-flex align-items-center">
+        <div class="d-flex align-items-center justify-content-between">
+            <a asp-controller="Home" asp-action="Index" class="logo d-flex align-items-center">
+                <img src="~/niceadmin/img/logo.png" alt="" />
+                <span class="d-none d-lg-block">AppDiti2025</span>
+            </a>
         </div>
-    </nav>
-</header>
-<div class="container">
-    <main role="main" class="pb-3">
+        <partial name="_LoginPartial" />
+    </header>
+    <main id="main" class="main mt-5">
         @RenderBody()
     </main>
-</div>
-
-<footer class="border-top footer text-muted">
-    <div class="container">
-        &copy; 2025 - AppDiti2025 - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-    </div>
-</footer>
-<script src="~/lib/jquery/dist/jquery.min.js"></script>
-<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-<script src="~/js/site.js" asp-append-version="true"></script>
-@await RenderSectionAsync("Scripts", required: false)
+    <script src="~/niceadmin/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="~/niceadmin/js/main.js"></script>
+    @await RenderSectionAsync("Scripts", false)
 </body>
 </html>

--- a/AppDiti2025/appsettings.json
+++ b/AppDiti2025/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "DataSource=app.db;Cache=Shared"
+    "DefaultConnection": "Host=localhost;Database=AppDiti2025;Username=postgres;Password=postgres"
   },
   "Logging": {
     "LogLevel": {

--- a/AppDiti2025/wwwroot/niceadmin
+++ b/AppDiti2025/wwwroot/niceadmin
@@ -1,0 +1,1 @@
+../NiceAdmin/assets


### PR DESCRIPTION
## Summary
- switch to PostgreSQL provider
- add base domain models (`Personne`, `Utilisateur`, `Admin`, `Client`)
- expose `Admins` and `Clients` in `ApplicationDbContext`
- scaffold simple controllers and index views
- replace layout with simplified NiceAdmin design
- include symlink to static NiceAdmin assets
- fix BOM and newline issues

## Testing
- `dotnet --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bfb576afc8323a1220f46266d3729